### PR TITLE
New  registry entry for 'VAT number' (LV-PVN)

### DIFF
--- a/lists/lv/lv-pvn.json
+++ b/lists/lv/lv-pvn.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "",
+        "publicDatabase": ""
+    },
+    "code": "LV-PVN",
+    "confirmed": true,
+    "coverage": [
+        "LV"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": ""
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "secondary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "VAT number",
+        "local": "Pievienot\u0101s v\u0113rt\u012bbas nodok\u013ca (PVN) re\u0123istr\u0101cijas numurs"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://dati.ur.gov.lv/register/"
+}


### PR DESCRIPTION
A new list has been proposed with the code LV-PVN

**List title:** VAT number

 Preview the platform with this list at [http://org-id.guide/_preview_branch/LV-PVN](http://org-id.guide/_preview_branch/LV-PVN)  (visiting [http://org-id.guide/list/LV-PVN](http://org-id.guide/list/LV-PVN) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.