### PR TITLE
New  registry entry for 'VAT number' (DE-USTID)

### DIFF
--- a/lists/de/de-ustid.json
+++ b/lists/de/de-ustid.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Without registration, one may find out about the company's legal name, registered office, and status. Any further information can be obtained upon registration. Retrieving published information is free of charge, any other is subject to a fee. There is English, French, Italian, and Spanish interface.",
+        "publicDatabase": ""
+    },
+    "code": "DE-USTID",
+    "confirmed": true,
+    "coverage": [
+        "DE"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "Common register portal of the German federal states provides  the registers of companies, cooperatives and partnerships and, to some extent, also of associations registered in all federal states in Germany as well as announcements for the register (publications)."
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "secondary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "VAT number",
+        "local": "Umsatzsteuer-Identifikationsnummer"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "https://www.handelsregister.de/rp_web/welcome.do"
+}


### PR DESCRIPTION
A new list has been proposed with the code DE-USTID

**List title:** VAT number

 Preview the platform with this list at [http://org-id.guide/_preview_branch/DE-USTID](http://org-id.guide/_preview_branch/DE-USTID)  (visiting [http://org-id.guide/list/DE-USTID](http://org-id.guide/list/DE-USTID) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.