### PR TITLE
New  registry entry for 'Commercial Register of the Kingdom of Spain' (ES-RMC)

### DIFF
--- a/lists/es/es-rmc.json
+++ b/lists/es/es-rmc.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "The Central Mercantile Register offers two methods of obtaining information about registered companies and/or company names: TRUE) USERS WITHOUT AGREEMENT. - They should pay the corresponding legal tax by credit card. 2) USERS WITH AGREEMENT.- They must use the password assigned by the Central Mercantile Register after the Agreement has been signed.",
+        "publicDatabase": ""
+    },
+    "code": "ES-RMC",
+    "confirmed": true,
+    "coverage": [
+        "ES"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "The Central Mercantile Register (1) provides the access to the companies information supplied by the Regional Mercantile Registers after the 1 January 1990, once the data has been organized and processed in accordance with Section 379 of the Mercantile Register Regulations currently in effect."
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "Commercial Register of the Kingdom of Spain",
+        "local": "El Registro Mercantil Central"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.rmc.es/Home.aspx"
+}


### PR DESCRIPTION
A new list has been proposed with the code ES-RMC

**List title:** Commercial Register of the Kingdom of Spain

 Preview the platform with this list at [http://org-id.guide/_preview_branch/ES-RMC](http://org-id.guide/_preview_branch/ES-RMC)  (visiting [http://org-id.guide/list/ES-RMC](http://org-id.guide/list/ES-RMC) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.