### PR TITLE
New  registry entry for 'National Trade Register Office' (RO-CUI)

### DIFF
--- a/lists/ro/ro-cui.json
+++ b/lists/ro/ro-cui.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Upon registration and payment of 45 lei, company details can be obtained.",
+        "publicDatabase": ""
+    },
+    "code": "RO-CUI",
+    "confirmed": true,
+    "coverage": [
+        "RO"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "General information for persons interested in carrying out certain regulated activities, as applicable (businesses, natural persons, legal persons, public institutions and authorities, etc.) "
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "National Trade Register Office",
+        "local": "Oficiul Na\u021bional al Registrului Comer\u021bului"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.onrc.ro/index.php/ro/\n"
+}


### PR DESCRIPTION
A new list has been proposed with the code RO-CUI

**List title:** National Trade Register Office

 Preview the platform with this list at [http://org-id.guide/_preview_branch/RO-CUI](http://org-id.guide/_preview_branch/RO-CUI)  (visiting [http://org-id.guide/list/RO-CUI](http://org-id.guide/list/RO-CUI) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.