### PR TITLE
New  registry entry for 'Uniform State Register of Legal Entities of Russian Federation' (RU-INN)

### DIFF
--- a/lists/ru/ru-inn.json
+++ b/lists/ru/ru-inn.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "7723861614",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Company information cannot be obtained without prior registration and/or payment (see prices at https://russianpartner.biz/tariffs.html). Example exstract: https://www.egrul.ru/examples/extract.pdf",
+        "publicDatabase": ""
+    },
+    "code": "RU-INN",
+    "confirmed": true,
+    "coverage": [
+        "RU"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": ""
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "Uniform State Register of Legal Entities of Russian Federation",
+        "local": "\u0415\u0434\u0438\u043d\u044b\u0439 \u0433\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u0435\u043d\u043d\u044b\u0439 \u0440\u0435\u0435\u0441\u0442\u0440 \u044e\u0440\u0438\u0434\u0438\u0447\u0435\u0441\u043a\u0438\u0445 \u043b\u0438\u0446"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "https://russianpartner.biz/ or https://www.egrul.ru/"
+}


### PR DESCRIPTION
A new list has been proposed with the code RU-INN

**List title:** Uniform State Register of Legal Entities of Russian Federation

 Preview the platform with this list at [http://org-id.guide/_preview_branch/RU-INN](http://org-id.guide/_preview_branch/RU-INN)  (visiting [http://org-id.guide/list/RU-INN](http://org-id.guide/list/RU-INN) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.