### PR TITLE
New  registry entry for 'VAT number' (LT-PVM)

### DIFF
--- a/lists/lt/lt-pvm.json
+++ b/lists/lt/lt-pvm.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "LT1 148467",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Not available in free version.",
+        "publicDatabase": ""
+    },
+    "code": "LT-PVM",
+    "confirmed": true,
+    "coverage": [
+        "LT"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": ""
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "secondary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "VAT number",
+        "local": "Prid\u0117tin\u0117s vert\u0117s mokestis"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.registrucentras.lt/jar/index_en.php"
+}


### PR DESCRIPTION
A new list has been proposed with the code LT-PVM

**List title:** VAT number

 Preview the platform with this list at [http://org-id.guide/_preview_branch/LT-PVM](http://org-id.guide/_preview_branch/LT-PVM)  (visiting [http://org-id.guide/list/LT-PVM](http://org-id.guide/list/LT-PVM) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.