### PR TITLE
New  registry entry for 'State Register of Commercial Entities (The Ministry of Taxes of Azerbaijan Republic) Internet Tax Administration' (AZ-IVI)

### DIFF
--- a/lists/az/az-ivi.json
+++ b/lists/az/az-ivi.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "9900014901",
+        "guidanceOnLocatingIds": "TIN (aka company registration number) is under `V\u00d6EN` header",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Company can be searched by TIN or legal name. Information provided: name of commercial organization, TIN, taxpayer's name, organizational-legal form, legal address, charter capital, fiscal year, legal representative, registration date. No English interface.",
+        "publicDatabase": ""
+    },
+    "code": "AZ-IVI",
+    "confirmed": true,
+    "coverage": [
+        "AZ"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "Available only in Azerbaijani"
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "State Register of Commercial Entities (The Ministry of Taxes of Azerbaijan Republic) Internet Tax Administration",
+        "local": "Kommersiya qurumlar\u0131n\u0131n d\u00f6vl\u0259t reyestri. Internet vergi idar\u0259si"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "https://www.e-taxes.gov.az/ebyn/commersialChecker.jsp"
+}


### PR DESCRIPTION
A new list has been proposed with the code AZ-IVI

**List title:** State Register of Commercial Entities (The Ministry of Taxes of Azerbaijan Republic) Internet Tax Administration

 Preview the platform with this list at [http://org-id.guide/_preview_branch/AZ-IVI](http://org-id.guide/_preview_branch/AZ-IVI)  (visiting [http://org-id.guide/list/AZ-IVI](http://org-id.guide/list/AZ-IVI) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.