### PR TITLE
New  registry entry for 'VAT number' (NL-BTW)

### DIFF
--- a/lists/nl/nl-btw.json
+++ b/lists/nl/nl-btw.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "123456789B01",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "",
+        "publicDatabase": ""
+    },
+    "code": "NL-BTW",
+    "confirmed": true,
+    "coverage": [
+        "NL"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": ""
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "secondary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "VAT number",
+        "local": "BTW nummer"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "https://www.kvk.nl/zoeken/handelsregister/"
+}


### PR DESCRIPTION
A new list has been proposed with the code NL-BTW

**List title:** VAT number

 Preview the platform with this list at [http://org-id.guide/_preview_branch/NL-BTW](http://org-id.guide/_preview_branch/NL-BTW)  (visiting [http://org-id.guide/list/NL-BTW](http://org-id.guide/list/NL-BTW) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.