### PR TITLE
New  registry entry for 'VAT number' (AT-UID)

### DIFF
--- a/lists/at/at-uid.json
+++ b/lists/at/at-uid.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "U12345678",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "",
+        "publicDatabase": ""
+    },
+    "code": "AT-UID",
+    "confirmed": true,
+    "coverage": [
+        "AT"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": ""
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "secondary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "VAT number",
+        "local": "Umsatzsteuer-Identifikationsnummer"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "https://www.justiz.gv.at/web2013/html/default/2c9484852308c2a601240b693e1c0860.de.html\n"
+}


### PR DESCRIPTION
A new list has been proposed with the code AT-UID

**List title:** VAT number

 Preview the platform with this list at [http://org-id.guide/_preview_branch/AT-UID](http://org-id.guide/_preview_branch/AT-UID)  (visiting [http://org-id.guide/list/AT-UID](http://org-id.guide/list/AT-UID) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.