### PR TITLE
New  registry entry for 'VAT number' (HU-AFA)

### DIFF
--- a/lists/hu/hu-afa.json
+++ b/lists/hu/hu-afa.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "12345678 (8 characters)",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "",
+        "publicDatabase": ""
+    },
+    "code": "HU-AFA",
+    "confirmed": true,
+    "coverage": [
+        "HU"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "\u00e1ltal\u00e1nos forgalmi ad\u00f3 serves as both tax number and VAT number."
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "VAT number",
+        "local": "\u00e1ltal\u00e1nos forgalmi ad\u00f3"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.e-cegjegyzek.hu/?cegkereses"
+}


### PR DESCRIPTION
A new list has been proposed with the code HU-AFA

**List title:** VAT number

 Preview the platform with this list at [http://org-id.guide/_preview_branch/HU-AFA](http://org-id.guide/_preview_branch/HU-AFA)  (visiting [http://org-id.guide/list/HU-AFA](http://org-id.guide/list/HU-AFA) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.