### PR TITLE
New  registry entry for 'Unified identification code (UIC)' (BG-EIK)

### DIFF
--- a/lists/bg/bg-eik.json
+++ b/lists/bg/bg-eik.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "",
+        "publicDatabase": ""
+    },
+    "code": "BG-EIK",
+    "confirmed": true,
+    "coverage": [
+        "BG"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "A unified code which certifies the legality of one's business and under which one's company is signed in the National Statistics Agency"
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "Unified identification code (UIC)",
+        "local": "\u0415\u0434\u0438\u043d\u043d\u0438\u044f\u0442 \u0438\u0434\u0435\u043d\u0442\u0438\u0444\u0438\u043a\u0430\u0446\u0438\u043e\u043d\u0435\u043d \u043a\u043e\u0434 (\u0415\u0418\u041a)"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "https://public.brra.bg/CheckUps/Verifications/VerificationPersonOrg.ra"
+}


### PR DESCRIPTION
A new list has been proposed with the code BG-EIK

**List title:** Unified identification code (UIC)

 Preview the platform with this list at [http://org-id.guide/_preview_branch/BG-EIK](http://org-id.guide/_preview_branch/BG-EIK)  (visiting [http://org-id.guide/list/BG-EIK](http://org-id.guide/list/BG-EIK) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.