### PR TITLE
New  registry entry for 'Tax Identification Number' (SI-TIN)

### DIFF
--- a/lists/si/si-tin.json
+++ b/lists/si/si-tin.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "59053283",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "",
+        "publicDatabase": ""
+    },
+    "code": "SI-TIN",
+    "confirmed": true,
+    "coverage": [
+        "SI"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "A unique code every legal entity or an individual enterpreneur must obtain."
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "secondary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "Tax Identification Number",
+        "local": "Dav\u010dna \u0161tevilka"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.ajpes.eu/prs/"
+}


### PR DESCRIPTION
A new list has been proposed with the code SI-TIN

**List title:** Tax Identification Number

 Preview the platform with this list at [http://org-id.guide/_preview_branch/SI-TIN](http://org-id.guide/_preview_branch/SI-TIN)  (visiting [http://org-id.guide/list/SI-TIN](http://org-id.guide/list/SI-TIN) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.