### PR TITLE
New  registry entry for 'JCN (Japanese Corporate Number). Japanese Corporate Registry - Houjintouki' (JP-JCN)

### DIFF
--- a/lists/jp/jp-jcn.json
+++ b/lists/jp/jp-jcn.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "availableOnline": "TRUE",
+        "exampleIdentifiers": "7010001008844",
+        "guidanceOnLocatingIds": "",
+        "languages": [
+            ""
+        ],
+        "onlineAccessDetails": "Company can be searched by legal name and corporate number. Search results provide corporate number, name, address, change history information. English interface available, search is free of charge. ",
+        "publicDatabase": ""
+    },
+    "code": "JP-JCN",
+    "confirmed": true,
+    "coverage": [
+        "JP"
+    ],
+    "data": {
+        "availability": [],
+        "dataAccessDetails": "",
+        "features": [],
+        "licenseDetails": "",
+        "licenseStatus": "open_license"
+    },
+    "deprecated": false,
+    "description": {
+        "en": "A code allocated to a company by the Japanese National Tax Agency. The registry itself is open and searchable by JCN (in Japanese only), but only limited information is available. More information on the corporate number (JCN) can be found here - http://www.nta.go.jp/foreign_language/corporate_number/ (National Tax Agency website). "
+    },
+    "formerPrefixes": [],
+    "links": {
+        "opencorporates": "",
+        "wikipedia": ""
+    },
+    "listType": "primary",
+    "meta": {
+        "lastUpdated": "",
+        "source": ""
+    },
+    "name": {
+        "en": "JCN (Japanese Corporate Number). Japanese Corporate Registry - Houjintouki",
+        "local": "\u6cd5\u4eba\u767b\u8a18)"
+    },
+    "sector": [],
+    "structure": [
+        "company"
+    ],
+    "subnationalCoverage": [],
+    "url": "http://www.houjin-bangou.nta.go.jp/"
+}


### PR DESCRIPTION
A new list has been proposed with the code JP-JCN

**List title:** JCN (Japanese Corporate Number). Japanese Corporate Registry - Houjintouki

 Preview the platform with this list at [http://org-id.guide/_preview_branch/JP-JCN](http://org-id.guide/_preview_branch/JP-JCN)  (visiting [http://org-id.guide/list/JP-JCN](http://org-id.guide/list/JP-JCN) when the preview is active or check the files changed options above.

Unless objections are raised, this update will be merged after 7 days.